### PR TITLE
Fix Default Value for `HF_HOME` Environment

### DIFF
--- a/src/animatediff/__init__.py
+++ b/src/animatediff/__init__.py
@@ -18,7 +18,7 @@ from tqdm import TqdmExperimentalWarning
 PACKAGE = __package__.replace("_", "-")
 PACKAGE_ROOT = Path(__file__).parent.parent
 
-HF_HOME = Path(getenv("HF_HOME", "~/.cache/huggingface"))
+HF_HOME = Path(getenv("HF_HOME", Path.home() / ".cache" / "huggingface"))
 HF_HUB_CACHE = Path(getenv("HUGGINGFACE_HUB_CACHE", HF_HOME.joinpath("hub")))
 
 HF_LIB_NAME = "animatediff-cli"


### PR DESCRIPTION
This pull request addresses an issue related to the default value of the `HF_HOME` environment variable in the `__init__.py` file.

The problem arises when the Stable Diffusion is not present locally; the application attempts to download it from the HuggingFace repository and store it in the designated `HF_HOME` directory. However, there seems to be an issue with Python's interpretation of `~/` as the home directory, resulting in the creation of an unintended and erroneous directory structure within my project.

![Screenshot](https://github.com/neggles/animatediff-cli/assets/10202888/17a97f96-1c1b-4416-bd73-6b1928661c62)

This pull request resolves the problem by properly handling the interpretation of home directory and ensuring that the Stable Diffusion is stored in the correct `HF_HOME` directory.