### PR TITLE
Fix Filename Too Long Error When Saving Video

### DIFF
--- a/src/animatediff/generate.py
+++ b/src/animatediff/generate.py
@@ -172,7 +172,8 @@ def run_inference(
     prompt_str = "_".join((prompt_tags[:6]))
 
     # generate the output filename and save the video
-    out_file = out_dir.joinpath(f"{idx:02d}_{seed}_{prompt_str}.gif")
+    out_str = f"{idx:02d}_{seed}_{prompt_str}"[:251]
+    out_file = out_dir.joinpath(f"{out_str}.gif")
     if return_dict is True:
         save_video(pipeline_output["videos"], out_file)
     else:


### PR DESCRIPTION
This pull request addresses an issue related to file name length when saving a video, which results in an "OSError: [Errno 36] File name too long" error. This problem could be caused by an excessively long filename, possibly due to an extended prompt. On Linux systems, the maximum allowable filename length is 255 bytes. This pull request restricts the filename to a maximum of 251 bytes, reserving 4 bytes for the ".gif" file extension.

```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/threeal/animate-diff-projects/animatediff-cli/src/animatediff/cli.py:324 in generate       │
│                                                                                                  │
│   321 │   │   │   │   seed = torch.seed()                                                        │
│   322 │   │   │   logger.info(f"Generation seed: {seed}")                                        │
│   323 │   │   │                                                                                  │
│ ❱ 324 │   │   │   output = run_inference(                                                        │
│   325 │   │   │   │   pipeline=pipeline,                                                         │
│   326 │   │   │   │   prompt=prompt,                                                             │
│   327 │   │   │   │   n_prompt=n_prompt,                                                         │
│                                                                                                  │
│ /home/threeal/animate-diff-projects/animatediff-cli/src/animatediff/generate.py:179 in           │
│ run_inference                                                                                    │
│                                                                                                  │
│   176 │   if return_dict is True:                                                                │
│   177 │   │   save_video(pipeline_output["videos"], out_file)                                    │
│   178 │   else:                                                                                  │
│ ❱ 179 │   │   save_video(pipeline_output, out_file)                                              │
│   180 │                                                                                          │
│   181 │   logger.info(f"Saved sample to {out_file}")                                             │
│   182 │   return pipeline_output                                                                 │
│                                                                                                  │
│ /home/threeal/animate-diff-projects/animatediff-cli/src/animatediff/utils/util.py:37 in          │
│ save_video                                                                                       │
│                                                                                                  │
│   34 │   frames = frames.mul(255).add_(0.5).clamp_(0, 255).permute(0, 2, 3, 1).to("cpu", torc    │
│   35 │                                                                                           │
│   36 │   images = [Image.fromarray(frame) for frame in frames]                                   │
│ ❱ 37 │   images[0].save(                                                                         │
│   38 │   │   fp=save_path, format="GIF", append_images=images[1:], save_all=True, duration=(1    │
│   39 │   )                                                                                       │
│   40                                                                                             │
│                                                                                                  │
│ /home/threeal/animate-diff-projects/animatediff-cli/.venv/lib/python3.10/site-packages/PIL/Image │
│ .py:2429 in save                                                                                 │
│                                                                                                  │
│   2426 │   │   │   │   # writer needs to go back and edit the written data.                      │
│   2427 │   │   │   │   fp = builtins.open(filename, "r+b")                                       │
│   2428 │   │   │   else:                                                                         │
│ ❱ 2429 │   │   │   │   fp = builtins.open(filename, "w+b")                                       │
│   2430 │   │                                                                                     │
│   2431 │   │   try:                                                                              │
│   2432 │   │   │   save_handler(self, fp, filename)                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
OSError: [Errno 36] File name too long: 
'output/2023-08-08T21-03-59-lyriel-lyriel_v16/03_6653196880059937000_As-I-have-gone-alone-in-there-and-with-my-treasures-bold_I-can-keep-my-secret-where-and-hint-
of-riches-new-and-old_Begin-it-where-warm-waters-halt-and-take-it-in-a-canyon-down_not-far-but-too-far-to-walk_put-in-below-the-home-of-brown.gif'
```